### PR TITLE
Change Protocol for self-adaption

### DIFF
--- a/resources/DirectoryLister.php
+++ b/resources/DirectoryLister.php
@@ -791,11 +791,12 @@ class DirectoryLister {
     protected function _getAppUrl() {
 
         // Get the server protocol
-        if (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') {
-            $protocol = 'https://';
-        } else {
-            $protocol = 'http://';
-        }
+        //if (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') {
+        //    $protocol = 'https://';
+        //} else {
+        //    $protocol = 'http://';
+        //}
+        $protocol = '//';
 
         // Get the server hostname
         $host = $_SERVER['HTTP_HOST'];


### PR DESCRIPTION
For Protocol self-adaption.When using nginx for proxy and configured SSL on nginx and .Nginx communicate apache with http protocol. Some of the url goes wrong.